### PR TITLE
IMAP improvements - Gmail compatibility, timeouts, speedup

### DIFF
--- a/prober/imap.go
+++ b/prober/imap.go
@@ -86,6 +86,11 @@ func IMAPReceiver(ctx context.Context, subject string, module config.IMAPReceive
 			level.Error(logger).Log("msg", "Error searching for messages", "err", err)
 			return
 		}
+
+		if len(seq) != 0 {
+			break
+		}
+
 		time.Sleep(1 * time.Second)
 
 		if err = c.Noop(); err != nil {

--- a/prober/imap.go
+++ b/prober/imap.go
@@ -87,6 +87,11 @@ func IMAPReceiver(ctx context.Context, subject string, module config.IMAPReceive
 			return
 		}
 		time.Sleep(1 * time.Second)
+
+		if err = c.Noop(); err != nil {
+			level.Error(logger).Log("msg", fmt.Sprintf("Error refreshing mailbox %q", module.Mailbox), "err", err)
+			return
+		}
 	}
 
 	seqset := new(imap.SeqSet)


### PR DESCRIPTION
Hi, thanks so much for releasing this delightful tool! It's so nice to hear about deliverability issues before my users notice...

Just a couple of improvements here:

- Checking a Gmail IMAP inbox would always hang because the server didn't want to tell us about new messages - fixed by emitting NOOP in the loop
- Bail when the scrape timeout is exceeded - so we can report total delivery failures
- Don't delay an extra second after a successful search